### PR TITLE
feat: Only monitor 1 device usage (with default value to /dev/xvda1)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,12 @@ resource "datadog_timeboard" "system" {
     prefix  = "environment"
   }
 
+  template_variable {
+    default = "${var.disk_device}"
+    name    = "disk_device"
+    prefix  = "device"
+  }
+
   graph {
     title     = "CPU Utilization (Rollup: max)"
     viz       = "timeseries"
@@ -62,7 +68,7 @@ resource "datadog_timeboard" "system" {
     autoscale = true
 
     request {
-      q    = "avg:system.disk.free{$cluster, $environment} by {host,device}"
+      q    = "avg:system.disk.free{$cluster, $environment, $disk_device} by {host,device}"
       type = "line"
     }
   }
@@ -73,7 +79,7 @@ resource "datadog_timeboard" "system" {
     autoscale = true
 
     request {
-      q          = "avg:system.disk.in_use{$cluster, $environment} by {host,device} * 100"
+      q          = "avg:system.disk.in_use{$cluster, $environment, $disk_device} by {host,device} * 100"
       aggregator = "avg"
       type       = "line"
     }
@@ -85,7 +91,7 @@ resource "datadog_timeboard" "system" {
     autoscale = true
 
     request {
-      q          = "avg:system.fs.inodes.in_use{$cluster, $environment} by {host,device} * 100"
+      q          = "avg:system.fs.inodes.in_use{$cluster, $environment, $disk_device} by {host,device} * 100"
       aggregator = "avg"
       type       = "line"
     }
@@ -374,7 +380,7 @@ module "monitor_disk_usage" {
   timeboard_id   = "${join(",", datadog_timeboard.system.*.id)}"
 
   name               = "${var.product_domain} - ${var.cluster} - ${var.environment} - Disk Usage is High on IP: {{ host.ip }} Name: {{ host.name }}"
-  query              = "avg(last_5m):avg:system.disk.in_use{cluster:${var.cluster}, environment:${var.environment}} by {host,device} * 100  >= ${var.disk_usage_thresholds["critical"]}"
+  query              = "avg(last_5m):avg:system.disk.in_use{cluster:${var.cluster}, environment:${var.environment}, device:${var.disk_device}} by {host,device} * 100  >= ${var.disk_usage_thresholds["critical"]}"
   thresholds         = "${var.disk_usage_thresholds}"
   message            = "${var.disk_usage_message}"
   escalation_message = "${var.disk_usage_escalation_message}"

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "cpu_usage_escalation_message" {
   description = "The escalation message when CPU Usage Monitor isn't resolved for given time"
 }
 
+variable "disk_device" {
+  type        = "string"
+  default     = "/dev/xvda1"
+  description = "The disk device that will be monitored"
+}
+
 variable "disk_usage_thresholds" {
   type = "map"
 


### PR DESCRIPTION
This changes will change disk usage dashboard and monitoring to only monitor `var.disk_device` (by default is /dev/xvda1)